### PR TITLE
Fix Migrate Refresh issue (table "admin_role" already exists)

### DIFF
--- a/src/database/migrations/2017_03_06_053834_create_admin_role_table.php
+++ b/src/database/migrations/2017_03_06_053834_create_admin_role_table.php
@@ -30,6 +30,6 @@ class CreateAdminRoleTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('role_admins');
+        Schema::dropIfExists('admin_role');
     }
 }


### PR DESCRIPTION
Fix Migrate Refresh issue SQLSTATE[HY000]: General error: 1 table "admin_role" already exists